### PR TITLE
Arreglar detección de archivo de juego Driver 2 región PAL (fix PAL game file detection)

### DIFF
--- a/Driver2_patcher/Form1.cs
+++ b/Driver2_patcher/Form1.cs
@@ -18,7 +18,7 @@ namespace Driver2_patcher
         //SLES_02994
         string refEU = "SLES_029.9";
         string ValorEU = "SLES_129.9*";
-        int PosicionEU = 154503145;
+        int PosicionEU = 542465493;
 
         string refUS = "SLUS_011.61";
         string ValorUS = "SLUS_013.18";            

--- a/Driver2_patcher/Form1.cs
+++ b/Driver2_patcher/Form1.cs
@@ -17,7 +17,7 @@ namespace Driver2_patcher
 
         //SLES_02994
         string refEU = "SLES_029.9";
-        string ValorEU = "SLES_129.9";
+        string ValorEU = "SLES_129.9*";
         int PosicionEU = 154503145;
 
         string refUS = "SLUS_011.61";


### PR DESCRIPTION
Hola q tal @larger0o 
Por alguna razón la versión 1.0 del Driver2_patcher solo detecta los archivos de imagen del juego Driver 2 de PS1 en región NTSC y no las de región PAL (incluyendo la de España, Alemania, Francia, e Italia).
Esta modificación trata de arreglar ese bug.
Necesita confirmación de que funciona, gracias!